### PR TITLE
Add unified mode to resources

### DIFF
--- a/resources/apt_repository.rb
+++ b/resources/apt_repository.rb
@@ -1,3 +1,4 @@
+unified_mode true
 property :uri, String, default: 'https://packages.microsoft.com/repos/edge', description: 'The uri of the repository'
 property :repo_name, String, default: 'microsoft-edge', description: 'The name of the repo (the name in the sources.list.d folder)'
 property :components, Array, default: %w(main)

--- a/resources/package.rb
+++ b/resources/package.rb
@@ -1,3 +1,4 @@
+unified_mode true
 property :package_name, String, default: 'microsoft-edge-dev', description: 'The name of the apt package'
 
 action :install do


### PR DESCRIPTION
Since chef 17 resources without unified_mode are deprecated so we need to add that to be compatible with chef 18